### PR TITLE
Maximum checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ criterion             | description                                      | notat
 `Never()`             | Never stop                                       |
 `NotANumber()`        | Stop when `NaN` encountered                       |
 `TimeLimit(t=0.5)`    | Stop after `t` hours                          |
+`NumberLimit(n)`      | Stop after `n` checks                          |
 `GL(alpha=2.0)`       | Stop after "Generalization Loss" exceeds `alpha` | ``GL_α``
 `PQ(alpha=0.75, k=5)` | Stop after "Progress-modified GL" exceeds `alpha` | ``PQ_α``
 `Patience(n=5)`       | Stop after `n` consecutive loss increases        | ``UP_s``

--- a/src/EarlyStopping.jl
+++ b/src/EarlyStopping.jl
@@ -5,7 +5,7 @@ using Statistics
 import Base.+
 
 export StoppingCriterion,
-    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, MaximumChecks,
+    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, NumberLimit,
     Disjunction, criteria, stopping_time, EarlyStopper,
     done!, message, needs_in_and_out_of_sample
 

--- a/src/EarlyStopping.jl
+++ b/src/EarlyStopping.jl
@@ -5,7 +5,7 @@ using Statistics
 import Base.+
 
 export StoppingCriterion,
-    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, Maximum bbChecks,
+    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, MaximumChecks,
     Disjunction, criteria, stopping_time, EarlyStopper,
     done!, message, needs_in_and_out_of_sample
 

--- a/src/EarlyStopping.jl
+++ b/src/EarlyStopping.jl
@@ -5,7 +5,7 @@ using Statistics
 import Base.+
 
 export StoppingCriterion,
-    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ,
+    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, Maximum bbChecks,
     Disjunction, criteria, stopping_time, EarlyStopper,
     done!, message, needs_in_and_out_of_sample
 

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -316,11 +316,10 @@ mutable struct MaximumChecks <: StoppingCriterion
 end
 MaximumChecks(; n) = MaximumChecks(n)
 
-update(criterion::MaximumChecks, loss) = (loss=loss, n_checks=0)
+update(criterion::MaximumChecks, loss) = 0
+update_training(criterion::MaximumChecks, loss) = 0
 @inline function update(criterion::MaximumChecks, loss, state)
-    _, n = state
-    n += 1
-    return (loss=loss, n_checks=n)
+    return state+1
 end
 
-done(criterion::MaximumChecks, state) = state.n_checks == criterion.n
+done(criterion::MaximumChecks, state) = state == criterion.n

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -306,19 +306,19 @@ $STOPPING_DOC
 A stop is triggered by `n` consecutive checking of done.
 
 """
-mutable struct MaximumChecks <: StoppingCriterion
+mutable struct NumberLimit <: StoppingCriterion
     n::Int
-    function MaximumChecks(n::Int)
+    function NumberLimit(n::Int)
         n > 0 ||
             throw(ArgumentError("The maxchecking level `n` must be positive. "))
         return new(n)
     end
 end
-MaximumChecks(; n) = MaximumChecks(n)
+NumberLimit(; n) = NumberLimit(n)
 
-update(criterion::MaximumChecks, loss) = 1
-@inline function update(criterion::MaximumChecks, loss, state)
+update(criterion::NumberLimit, loss) = 1
+@inline function update(criterion::NumberLimit, loss, state)
     return state+1
 end
 
-done(criterion::MaximumChecks, state) = state == criterion.n
+done(criterion::NumberLimit, state) = state == criterion.n

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -316,11 +316,11 @@ mutable struct MaximumChecks <: StoppingCriterion
 end
 MaximumChecks(; n) = MaximumChecks(n)
 
-update(criterion::MaximumChecks, loss) = (loss=loss, n_increases=0)
+update(criterion::MaximumChecks, loss) = (loss=loss, n_checks=0)
 @inline function update(criterion::MaximumChecks, loss, state)
     _, n = state
     n += 1
-    return (loss=loss, n_increases=n)
+    return (loss=loss, n_checks=n)
 end
 
-done(criterion::MaximumChecks, state) = state.n_increases == criterion.n
+done(criterion::MaximumChecks, state) = state.n_checks == criterion.n

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -298,10 +298,6 @@ end
 
 done(criterion::Patience, state) = state.n_increases == criterion.n
 
-## PATIENCE
-
-# This is UP_s in Prechelt 1998
-
 """
     MaximumChecks(n::Int)
 

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -316,8 +316,8 @@ mutable struct MaximumChecks <: StoppingCriterion
 end
 MaximumChecks(; n) = MaximumChecks(n)
 
-update(criterion::MaximumChecks, loss) = 0
-update_training(criterion::MaximumChecks, loss) = 0
+update(criterion::MaximumChecks, loss) = 1
+update_training(criterion::MaximumChecks, loss) = 1
 @inline function update(criterion::MaximumChecks, loss, state)
     return state+1
 end

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -317,7 +317,6 @@ end
 MaximumChecks(; n) = MaximumChecks(n)
 
 update(criterion::MaximumChecks, loss) = 1
-update_training(criterion::MaximumChecks, loss) = 1
 @inline function update(criterion::MaximumChecks, loss, state)
     return state+1
 end

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -297,3 +297,34 @@ update(criterion::Patience, loss) = (loss=loss, n_increases=0)
 end
 
 done(criterion::Patience, state) = state.n_increases == criterion.n
+
+## PATIENCE
+
+# This is UP_s in Prechelt 1998
+
+"""
+    MaximumChecks(n::Int)
+
+$STOPPING_DOC
+
+A stop is triggered by `n` consecutive checking of done.
+
+"""
+mutable struct MaximumChecks <: StoppingCriterion
+    n::Int
+    function MaximumChecks(n::Int)
+        n > 0 ||
+            throw(ArgumentError("The maxchecking level `n` must be positive. "))
+        return new(n)
+    end
+end
+MaximumChecks(; n) = MaximumChecks(n)
+
+update(criterion::MaximumChecks, loss) = (loss=loss, n_increases=0)
+@inline function update(criterion::MaximumChecks, loss, state)
+    _, n = state
+    n += 1
+    return (loss=loss, n_increases=n)
+end
+
+done(criterion::MaximumChecks, state) = state.n_increases == criterion.n

--- a/test/criteria.jl
+++ b/test/criteria.jl
@@ -151,11 +151,11 @@ end
     @test stopping_time(Patience(n=1), losses) == 3
 end
 
-@testset "MaximumChecks" begin
-    @test_throws ArgumentError MaximumChecks(n=0)
+@testset "NumberLimit" begin
+    @test_throws ArgumentError NumberLimit(n=0)
 
     for i in 1:length(losses)
-        @test stopping_time(MaximumChecks(i), losses) == i
+        @test stopping_time(NumberLimit(i), losses) == i
     end
 end
 

--- a/test/criteria.jl
+++ b/test/criteria.jl
@@ -34,6 +34,7 @@ end
                              verbosity=1))
 end
 
+
 struct SleepyIterator{T}
     iter::T
     t::Float64
@@ -148,6 +149,14 @@ end
     @test stopping_time(Patience(n=3), losses) == 5
     @test stopping_time(Patience(n=2), losses) == 4
     @test stopping_time(Patience(n=1), losses) == 3
+end
+
+@testset "MaximumChecks" begin
+    @test_throws ArgumentError MaximumChecks(n=0)
+
+    for i in 1:6
+        @test stopping_time(MaximumChecks(i), losses) == i+1
+    end
 end
 
 true

--- a/test/criteria.jl
+++ b/test/criteria.jl
@@ -154,8 +154,8 @@ end
 @testset "MaximumChecks" begin
     @test_throws ArgumentError MaximumChecks(n=0)
 
-    for i in 1:6
-        @test stopping_time(MaximumChecks(i), losses) == i+1
+    for i in 1:length(losses)
+        @test stopping_time(MaximumChecks(i), losses) == i
     end
 end
 


### PR DESCRIPTION
Add a criterion that stop after a maximum number of checks. For instance:

stopper=EarlyStopper(Patience(5), MaximumChecks(100))

it will stop if for 5 times the loss got worse, until a maximum of 100 checking. It is useful  to have a maximum number of training. Usually it will be use with Patience and/or TimeLimit.

I am not sure about the name, it is my best proposal, but I am open to change it.