### PR TITLE
add Threshold criterion

### DIFF
--- a/src/EarlyStopping.jl
+++ b/src/EarlyStopping.jl
@@ -6,7 +6,8 @@ import Base.+
 
 export StoppingCriterion,
     Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, NumberLimit,
-    Disjunction, criteria, stopping_time, EarlyStopper,
+    Threshold, Disjunction,
+    criteria, stopping_time, EarlyStopper,
     done!, message, needs_in_and_out_of_sample
 
 include("api.jl")

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -337,7 +337,7 @@ done(criterion::NumberLimit, state) = state == criterion.n
 # ## THRESHOLD
 
 """
-    Threshold(value)
+    Threshold(; value=0.0)
 
 $STOPPING_DOC
 
@@ -346,15 +346,8 @@ A stop is triggered as soon as the loss drops below `value`.
 """
 mutable struct Threshold <: StoppingCriterion
     value::Float64
-    function Threshold(value)
-        value isa Nothing &&
-            throw(ArgumentError(
-                "You must specify a threshold, as in "*
-                "`Threshold(0.213)`. "))
-        return new(value)
-    end
 end
-Threshold(; value=nothing) = Threshold(value)
+Threshold(; value=0.0) = Threshold(value)
 
 update(criterion::Threshold, loss) = loss
 update(criterion::Threshold, loss, state) = loss

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -332,3 +332,33 @@ end
 update(criterion::NumberLimit, loss, ::Nothing) = update(criterion, loss)
 
 done(criterion::NumberLimit, state) = state == criterion.n
+
+
+# ## THRESHOLD
+
+"""
+    Threshold(value)
+
+$STOPPING_DOC
+
+A stop is triggered as soon as the loss drops below `value`.
+
+"""
+mutable struct Threshold <: StoppingCriterion
+    value::Float64
+    function Threshold(value)
+        value isa Nothing &&
+            throw(ArgumentError(
+                "You must specify a threshold, as in "*
+                "`Threshold(0.213)`. "))
+        return new(value)
+    end
+end
+Threshold(; value=nothing) = Threshold(value)
+
+update(criterion::Threshold, loss) = loss
+update(criterion::Threshold, loss, state) = loss
+# in case first loss consumed was a training loss:
+update(criterion::Threshold, loss, ::Nothing) = loss
+
+done(criterion::Threshold, state) = state < criterion.value

--- a/test/criteria.jl
+++ b/test/criteria.jl
@@ -159,6 +159,12 @@ end
     end
 end
 
+@testset "Threshold" begin
+    @test_throws ArgumentError Threshold()
+    @test_throws ArgumentError Threshold(value=nothing)
+    stopping_time(Threshold(2.5), Float64[12, 32, 3, 2, 5, 7]) == 4
+end
+
 @testset "robustness to first loss being a training loss" begin
     for C in subtypes(StoppingCriterion)
         losses = float.(4:-1:1)

--- a/test/criteria.jl
+++ b/test/criteria.jl
@@ -160,8 +160,7 @@ end
 end
 
 @testset "Threshold" begin
-    @test_throws ArgumentError Threshold()
-    @test_throws ArgumentError Threshold(value=nothing)
+    @test Threshold().value == 0.0
     stopping_time(Threshold(2.5), Float64[12, 32, 3, 2, 5, 7]) == 4
 end
 


### PR DESCRIPTION
```
  Threshold(value)

  An early stopping criterion for loss-reporting iterative algorithms. 

  A stop is triggered as soon as the loss drops below value.
```