### PR TITLE
Replace NumberLimit -> CountLimit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EarlyStopping"
 uuid = "792122b4-ca99-40de-a6bc-6742525f08b6"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ criterion             | description                                           | 
 `Never()`             | Never stop                                            |
 `NotANumber()`        | Stop when `NaN` encountered                           |
 `TimeLimit(t=0.5)`    | Stop after `t` hours                                  |
-`NumberLimit(n=100)`  | Stop after `n` loss updates (excl. "training losses") |
+`CountLimit(n=100)`  | Stop after `n` loss updates (excl. "training losses") |
 `Threshold(value=0.0)`| Stop when `loss < value`                              | 
 `GL(alpha=2.0)`       | Stop after "Generalization Loss" exceeds `alpha`      | ``GL_α``
 `PQ(alpha=0.75, k=5)` | Stop after "Progress-modified GL" exceeds `alpha`     | ``PQ_α``

--- a/src/EarlyStopping.jl
+++ b/src/EarlyStopping.jl
@@ -5,7 +5,7 @@ using Statistics
 import Base.+
 
 export StoppingCriterion,
-    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, NumberLimit,
+    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, CountLimit,
     Threshold, Disjunction,
     criteria, stopping_time, EarlyStopper,
     done!, message, needs_training_losses

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -313,7 +313,7 @@ needs_loss(::Type{<:Patience}) = true
 # # NUMBER LIMIT
 
 """
-    NumberLimit(; n=100)
+    CountLimit(; n=100)
 
 $STOPPING_DOC
 
@@ -324,24 +324,24 @@ If wrapped in a `stopper::EarlyStopper`, this is the number of calls
 to `done!(stopper)`.
 
 """
-struct NumberLimit <: StoppingCriterion
+struct CountLimit <: StoppingCriterion
     n::Int
-    function NumberLimit(n::Int)
+    function CountLimit(n::Int)
         n > 0 ||
             throw(ArgumentError("`n` must be positive. "))
         return new(n)
     end
 end
-NumberLimit(; n=100) = NumberLimit(n)
+CountLimit(; n=100) = CountLimit(n)
 
-update(criterion::NumberLimit, loss) = 1
-@inline function update(criterion::NumberLimit, loss, state)
+update(criterion::CountLimit, loss) = 1
+@inline function update(criterion::CountLimit, loss, state)
     return state+1
 end
 # in case first loss consumed was a training loss:
-update(criterion::NumberLimit, loss, ::Nothing) = update(criterion, loss)
+update(criterion::CountLimit, loss, ::Nothing) = update(criterion, loss)
 
-done(criterion::NumberLimit, state) = state == criterion.n
+done(criterion::CountLimit, state) = state == criterion.n
 
 
 # ## THRESHOLD

--- a/test/criteria.jl
+++ b/test/criteria.jl
@@ -163,15 +163,15 @@ end
     @test !EarlyStopping.needs_training_losses(Patience())
 end
 
-@testset "NumberLimit" begin
-    @test_throws ArgumentError NumberLimit(n=0)
+@testset "CountLimit" begin
+    @test_throws ArgumentError CountLimit(n=0)
 
     for i in 1:length(losses)
-        @test stopping_time(NumberLimit(i), losses) == i
+        @test stopping_time(CountLimit(i), losses) == i
     end
 
-    @test !EarlyStopping.needs_loss(NumberLimit())
-    @test !EarlyStopping.needs_training_losses(NumberLimit())
+    @test !EarlyStopping.needs_loss(CountLimit())
+    @test !EarlyStopping.needs_training_losses(CountLimit())
 
 end
 


### PR DESCRIPTION
Turns out that the choice `NumberLimit` is not so great, basically because `Number` is a julia abstract type.

IterationControl.jl now adds a new control called `NumberCount(f)` which calls `f` on the control cycle count but it would have been more natural to call it just `Number`, which is already taken. Since there is also the total number of *iterations* of the underlying model, the namespace is getting crowded. 

So I propose renaming `NumberLimit` -> `CountLimit` and in IterationControl.jl, renaming `NumberCount` -> `Count`. 

A breaking change now is unlikely to affect anyone except yours truly 😉 

cc @dmolina 

