### PR TITLE
Add NumberSinceBest criterion

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ criterion             | description                                           | 
 `NotANumber()`        | Stop when `NaN` encountered                           |
 `TimeLimit(t=0.5)`    | Stop after `t` hours                                  |
 `NumberLimit(n=100)`  | Stop after `n` loss updates (excl. "training losses") |
+`NumberSinceBest(n=6)`| Stop after `n` loss updates (excl. "training losses") |
 `Threshold(value=0.0)`| Stop when `loss < value`                              | 
 `GL(alpha=2.0)`       | Stop after "Generalization Loss" exceeds `alpha`      | ``GL_α``
 `PQ(alpha=0.75, k=5)` | Stop after "Progress-modified GL" exceeds `alpha`     | ``PQ_α``

--- a/src/EarlyStopping.jl
+++ b/src/EarlyStopping.jl
@@ -5,7 +5,9 @@ using Statistics
 import Base.+
 
 export StoppingCriterion,
-    Never, NotANumber, TimeLimit, GL, Patience, UP, PQ, NumberLimit,
+    Never, NotANumber, TimeLimit, GL, NumberSinceBest,
+    Patience,
+    UP, PQ, NumberLimit,
     Threshold, Disjunction,
     criteria, stopping_time, EarlyStopper,
     done!, message, needs_training_losses

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -318,7 +318,7 @@ needs_loss(::Type{<:Patience}) = true
 $STOPPING_DOC
 
 A stop is triggered when the number of calls to the control, since the
-lowest previous value of the loss, is `n`.
+lowest value of the loss so far, is `n`.
 
 """
 struct NumberSinceBest <: StoppingCriterion

--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -313,7 +313,7 @@ needs_loss(::Type{<:Patience}) = true
 ## NUMBER SINCE BEST
 
 """
-    NumberSinceBest(; n=5)
+    NumberSinceBest(; n=6)
 
 $STOPPING_DOC
 

--- a/test/criteria.jl
+++ b/test/criteria.jl
@@ -163,6 +163,23 @@ end
     @test !EarlyStopping.needs_training_losses(Patience())
 end
 
+@testset "NumberSinceBest" begin
+    @test_throws ArgumentError NumberSinceBest(n=0)
+    @test stopping_time(NumberSinceBest(n=6), losses) == 8
+    @test stopping_time(NumberSinceBest(n=5), losses) == 7
+    @test stopping_time(NumberSinceBest(n=4), losses) == 6
+    @test stopping_time(NumberSinceBest(n=3), losses) == 5
+    @test stopping_time(NumberSinceBest(n=2), losses) == 4
+    @test stopping_time(NumberSinceBest(n=1), losses) == 3
+
+    losses2 = Float64[10, 9, 8, 9, 10, 7, 10, 10, 10, 10]
+    @test stopping_time(NumberSinceBest(n=2), losses2) == 5
+    @test stopping_time(NumberSinceBest(n=3), losses2) == 9
+
+    @test EarlyStopping.needs_loss(NumberSinceBest())
+    @test !EarlyStopping.needs_training_losses(NumberSinceBest())
+end
+
 @testset "NumberLimit" begin
     @test_throws ArgumentError NumberLimit(n=0)
 


### PR DESCRIPTION
```

  NumberSinceBest(; n=6)

  An early stopping criterion for loss-reporting iterative algorithms. 

  A stop is triggered when the number of calls to the control, since the lowest 
  value of the loss so far, is n.
```

@jeremiedb